### PR TITLE
Update plugin-adapter.py

### DIFF
--- a/plugin-adapter.py
+++ b/plugin-adapter.py
@@ -560,7 +560,7 @@ async def get_block_count(currency):
 
     socket = coins[currency]['socket']
 
-    res = await socket.send_message("getblockcount", (), timeout=5)
+    res = await socket.send_message("getblockcount", (), timeout=1)
 
     if res == OS_ERROR or res == OTHER_EXCEPTION:
         return None


### PR DESCRIPTION
reduce timeout for get_block_count call used to provide 'heights', this to improve responsiveness of the 'height' call, 

non responding container will produce a 'null' result for this coin.

* getblockcount is fast on core wallet / utxo_plugin, largely sub 1 second